### PR TITLE
Added ignores and removed SDK_BASE, EHAL from makefile

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,4 +5,4 @@
 /logs/
 /Debug52/
 /deploy/current.txt
-./_build/
+_build/

--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@
 /logs/
 /Debug52/
 /deploy/current.txt
+._build/

--- a/.gitignore
+++ b/.gitignore
@@ -5,4 +5,4 @@
 /logs/
 /Debug52/
 /deploy/current.txt
-._build/
+./_build/

--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@
 /logs/
 /Debug52/
 /deploy/current.txt
+./_build/

--- a/makefile
+++ b/makefile
@@ -11,7 +11,9 @@ TARGET_BOARD         ?= BOARD_PCA10031
 # Define relative paths to SDK components
 #------------------------------------------------------------------------------
 
-SDK_BASE      := $(HOME)/nrf/sdk/nrf_sdk_9_0
+# *** Make sure SDK_BASE is defined as an environment variable, or define it here
+#SDK_BASE	  := $(HOME)/path/to/sdk
+
 COMPONENTS    := $(SDK_BASE)/components
 TEMPLATE_PATH := $(COMPONENTS)/toolchain/gcc
 EHAL_PATH     := $(HOME)/nrf/sdk/ehal_latest

--- a/makefile
+++ b/makefile
@@ -11,10 +11,10 @@ TARGET_BOARD         ?= BOARD_PCA10031
 # Define relative paths to SDK components
 #------------------------------------------------------------------------------
 
-# *** Make sure SDK_BASE is defined as an environment variable, or define it here
-#SDK_BASE	  := $(HOME)/path/to/sdk
+# *** Make sure NRF51_SDK_BASE is defined as an environment variable, or define it here
+#NRF51_SDK_BASE	  := $(HOME)/path/to/sdk
 
-COMPONENTS    := $(SDK_BASE)/components
+COMPONENTS    := $(NRF51_SDK_BASE)/components
 TEMPLATE_PATH := $(COMPONENTS)/toolchain/gcc
 EHAL_PATH     := $(HOME)/nrf/sdk/ehal_latest
 LINKER_SCRIPT := ./linker/gcc_nrf51_s130_32kb.ld

--- a/makefile
+++ b/makefile
@@ -14,6 +14,10 @@ TARGET_BOARD         ?= BOARD_PCA10031
 # *** Make sure NRF51_SDK_BASE is defined as an environment variable, or define it here
 #NRF51_SDK_BASE	  := $(HOME)/path/to/sdk
 
+# *** Make sure EHAL_PATH is defined as an environment variable, or define it here
+# Download EHAL from https://github.com/I-SYST/EHAL
+#EHAL_PATH	  := $(HOME)/path/to/ehal
+
 COMPONENTS    := $(NRF51_SDK_BASE)/components
 TEMPLATE_PATH := $(COMPONENTS)/toolchain/gcc
 LINKER_SCRIPT := ./linker/gcc_nrf51_s130_32kb.ld

--- a/makefile
+++ b/makefile
@@ -11,10 +11,11 @@ TARGET_BOARD         ?= BOARD_PCA10031
 # Define relative paths to SDK components
 #------------------------------------------------------------------------------
 
-SDK_BASE      := $(HOME)/nrf/sdk/nrf_sdk_9_0
-COMPONENTS    := $(SDK_BASE)/components
+# *** Make sure NRF51_SDK_BASE is defined as an environment variable, or define it here
+#NRF51_SDK_BASE	  := $(HOME)/path/to/sdk
+
+COMPONENTS    := $(NRF51_SDK_BASE)/components
 TEMPLATE_PATH := $(COMPONENTS)/toolchain/gcc
-EHAL_PATH     := $(HOME)/nrf/sdk/ehal_latest
 LINKER_SCRIPT := ./linker/gcc_nrf51_s130_32kb.ld
 OUTPUT_NAME   := FruityMesh
 

--- a/makefile
+++ b/makefile
@@ -16,7 +16,6 @@ TARGET_BOARD         ?= BOARD_PCA10031
 
 COMPONENTS    := $(NRF51_SDK_BASE)/components
 TEMPLATE_PATH := $(COMPONENTS)/toolchain/gcc
-EHAL_PATH     := $(HOME)/nrf/sdk/ehal_latest
 LINKER_SCRIPT := ./linker/gcc_nrf51_s130_32kb.ld
 OUTPUT_NAME   := FruityMesh
 


### PR DESCRIPTION
Replaced SDK_PATH & EHAL defines with a comment to keep the makefile agnostic
Renamed SDK_PATAH to NRF51_SDK_PATH to be more specific.
Added ignore to git for _build/
